### PR TITLE
Use vue-tooltip as base css class

### DIFF
--- a/src/directives/tooltip.js
+++ b/src/directives/tooltip.js
@@ -1,7 +1,7 @@
 import Utils from 'popper.js/dist/popper-utils';
 import Popper from 'popper.js';
 
-const BASE_CLASS = 'tooltip';
+const BASE_CLASS = 'vue-tooltip';
 const PLACEMENT = ['top', 'left', 'right', 'bottom', 'auto'];
 
 const DEFAULT_OPTIONS = {


### PR DESCRIPTION
`tooltip` as base css class is a wrong choice IMHO - it's just too generic. In example, it currently prevents user to use bootstrap tooltip css along with vue-directive-tooltip.