### PR TITLE
[BUGFIX] IE11 html by content not working

### DIFF
--- a/docs/js/vueDirectiveTooltip.js
+++ b/docs/js/vueDirectiveTooltip.js
@@ -3407,9 +3407,13 @@ var Tootlip = function () {
             this.tooltip.options.title = _content;
             wrapper.textContent = _content;
         } else if (isElement$1(_content)) {
+            var clonedNode = _content.cloneNode(true);
             wrapper.innerHTML = '';
-            this.tooltip.options.title = _content;
-            wrapper.appendChild(_content);
+            this.tooltip.options.title = clonedNode;
+            wrapper.appendChild(clonedNode);
+            if (isElement$1(_content.parentNode)) {
+                _content.parentNode.removeChild(_content);
+            }
         } else {
             console.error('unsupported content type', _content);
         }

--- a/src/directives/tooltip.js
+++ b/src/directives/tooltip.js
@@ -167,9 +167,13 @@ export default class Tootlip {
             this.tooltip.options.title = content;
             wrapper.textContent = content;
         } else if (isElement(content)) {
+            var clonedNode = content.cloneNode(true);
             wrapper.innerHTML = '';
-            this.tooltip.options.title = content;
-            wrapper.appendChild(content);
+            this.tooltip.options.title = clonedNode;
+            wrapper.appendChild(clonedNode);
+            if (isElement(content.parentNode)) {
+                content.parentNode.removeChild(content);
+            }
         } else {
             console.error('unsupported content type', content);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**: IE11 tooltip with HTML content by id now working

**Summary**: clone current element before appendChild and remove the original

**Does this PR introduce a breaking change?**: no
