### PR TITLE
Remove popper-utils dependency

### DIFF
--- a/src/directives/tooltip.js
+++ b/src/directives/tooltip.js
@@ -1,4 +1,3 @@
-import Utils from 'popper.js/dist/popper-utils';
 import Popper from 'popper.js';
 
 const BASE_CLASS = 'h-tooltip';
@@ -82,7 +81,7 @@ export default class Tooltip {
         let $popper = document.createElement('div');
         $popper.setAttribute('id', `tooltip-${randomId()}`);
         $popper.setAttribute('class', `${BASE_CLASS} ${this._options.class}`);
-        Utils.setStyles($popper, {display: 'none'});
+        $popper.style.display = 'none';
 
         // make arrow
         let $arrow = document.createElement('div');


### PR DESCRIPTION
Fixes #19. Looks like [`setStyles`](https://github.com/FezVrasta/popper.js/blob/master/packages/popper/src/utils/setStyles.js) just does this anyway, and it's the only place it's used.