### PR TITLE
Add delay to show

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ A **lot of options** make this tooltip convenient:
 - **content**: simple text or use another html tag
 - **positioning** (right, left, ...)
 - **positioning variants**: start | end. ex: bottom.end, top.start, right.end, etc...
-- **delay** to hide (in ms)
+- **delayToHide** (in ms)
+- **delayToShow** (in ms)
 - **offset** (from the target in px)
 - choose from **several triggers** (hover, focus, click)
 - **full programmatic**, you choose when to show/hide the tooltip

--- a/src/directives/tooltip-directive.js
+++ b/src/directives/tooltip-directive.js
@@ -67,7 +67,8 @@ export default {
 };
 
 function filterBindings (binding) {
-    const delay = !binding.value || isNaN(binding.value.delay) ? Tooltip._defaults.delay : binding.value.delay;
+    const delayToShow = !binding.value || isNaN(binding.value.delayToShow) ? Tooltip._defaults.delayToShow : binding.value.delayToShow;
+    const delayToHide = !binding.value || isNaN(binding.value.delayToHide) ? Tooltip._defaults.delayToHide : binding.value.delayToHide;
 
     return {
         class: getClass(binding),
@@ -77,7 +78,8 @@ function filterBindings (binding) {
         triggers: getTriggers(binding),
         fixIosSafari: binding.modifiers.ios || false,
         offset: (binding.value && binding.value.offset) ? binding.value.offset : Tooltip._defaults.offset,
-        delay
+        delayToShow,
+        delayToHide
     };
 }
 

--- a/src/directives/tooltip.js
+++ b/src/directives/tooltip.js
@@ -11,7 +11,8 @@ const EVENTS = {
 
 const DEFAULT_OPTIONS = {
     container: false,
-    delay: 200,
+    delayToShow: 200,
+    delayToHide: 100,
     instance: null, // the popper.js instance
     fixIosSafari: false,
     eventsEnabled: true,
@@ -268,20 +269,17 @@ export default class Tooltip {
     }
 
     toggle (visible, autoHide = true) {
-        let delay = this._options.delay;
+        let delay = visible ? this._options.delayToShow : this._options.delayToHide;
 
         if (this._disabled === true) {
             visible = false;
             delay = 0;
+            delayToHide = 0;
             return;
         }
 
         if (typeof visible !== 'boolean') {
             visible = !this._visible;
-        }
-
-        if (visible === true) {
-            delay = 0;
         }
 
         clearTimeout(this._clearDelay);


### PR DESCRIPTION
**What kind of change does this PR introduce?**:
Implement delay to show as requested in #15.

**Did you add tests for your changes?**:
No

**Summary**:
Added the option `delayToShow`, which delays the appearance of tooltips until the cursor has been hovering over an element for a certain amount of time.
Renamed `delay` option to `delayToHide` for clarity.

**Does this PR introduce a breaking change?**:
Yes (renamed the `delay` option to `delayToHide` and added a default delay to show)

**Other**:
